### PR TITLE
Add support for async bootstrappers & middleware support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-kernel",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An easy way to create simple interfaces",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
+    "bluebird": "^3.4.1",
     "invariant": "^2.2.1",
     "simple-interface": "^0.1.3"
   },

--- a/src/createKernel.js
+++ b/src/createKernel.js
@@ -17,6 +17,7 @@ export default function createKernel(options = {}) {
   )
 
   const bootstrappers = [].concat(options.bootstrappers)
+  const middlewares = [].concat(options.middlewares || [])
 
   return {
     /**
@@ -40,9 +41,39 @@ export default function createKernel(options = {}) {
         if (isEmpty(context)) {
           context = undefined
         }
+
+        bootstrapper = applyMiddlewares(bootstrapper, middlewares)
+
         return bootstrapper.bootstrap(context)
       }, {})
     }
   }
 }
+
+/**
+ * Apply given middlewares to bootstrapper.
+ *
+ * @public
+ * @param {BootstrapperInterface} bootstrapper
+ * @param {Array<MiddlewareInterface>} middlewares
+ * @returns {function}
+ */
+const applyMiddlewares = (bootstrapper, middlewares) => {
+
+  middlewares = middlewares.slice()
+  middlewares.reverse()
+
+  let { bootstrap } = bootstrapper
+
+  middlewares.forEach(middleware => {
+    bootstrap = middleware(bootstrapper)(bootstrap)
+  })
+
+  return Object.assign({}, bootstrapper, { bootstrap })
+}
+
+const isEmpty = obj => (
+  Object.keys(obj).length === 0 && obj.constructor === Object
+)
+
 

--- a/test/test.js
+++ b/test/test.js
@@ -29,15 +29,18 @@ describe('simple-kernel', () => {
   })
 
   it('runs each registered bootstrapper', (done) => {
-    let flags = {}
     let foo = {
-      bootstrap() {
-        flags.foo = true
+      bootstrap(context = {}) {
+        return Object.assign({}, context, {
+          foo: true
+        })
       }
     }
     let bar = {
-      bootstrap() {
-        flags.bar = true
+      bootstrap(context = {}) {
+        return Object.assign({}, context, {
+          bar: true
+        })
       }
     }
 
@@ -47,13 +50,13 @@ describe('simple-kernel', () => {
       ]
     })
 
-    kernel.boot().then(() => {
-      expect(flags).toEqual({
+    kernel.boot().then(res => {
+      expect(res).toEqual({
         foo: true,
         bar: true
       })
       done()
-    })
+    }).catch(console.error.bind(console))
   })
 
   it('carries over a context', (done) => {
@@ -77,7 +80,7 @@ describe('simple-kernel', () => {
         bar: true
       })
       done()
-    }).catch(console.log.bind(console))
+    }).catch(done)
   })
 
   it('can have bootstrapper with default context', (done) => {
@@ -101,7 +104,7 @@ describe('simple-kernel', () => {
         foo: true,
         bar: true
       })
-    })
+    }).catch(done)
 
     // each time the first bootstrapper's default context
     // will be injected. order is important.
@@ -115,5 +118,124 @@ describe('simple-kernel', () => {
       })
       done()
     })
+  })
+
+  it('should handle errors', (done) => {
+    let bootstrapper = {
+      bootstrap(context = {}) {
+        throw new Error('error happened')
+      }
+    }
+
+    const kernel = createKernel({
+      bootstrappers: [bootstrapper]
+    })
+
+    kernel.boot().catch(error => {
+      expect(error).toBeA(Error)
+      expect(error.message).toBe('error happened')
+      done()
+    })
+  })
+
+  describe('async bootstrappers', (done) => {
+    it('waits for promise to resolve before switching to next bootstrapper', (done) => {
+      const asyncBootstrapper = {
+        bootstrap(context = {}) {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(Object.assign({}, context, {async: true}))
+            }, 10)
+          })
+        }
+      }
+
+      const syncBootstrapper = {
+        bootstrap(context = {}) {
+          return Object.assign({}, context, {sync: true})
+        }
+      }
+
+      const kernel = createKernel({
+        bootstrappers: [
+          syncBootstrapper,
+          asyncBootstrapper
+        ]
+      })
+
+      kernel.boot().then(res => {
+        expect(res).toEqual({
+          async: true,
+          sync: true
+        })
+        done()
+      })
+    })
+
+    it('stops execution of bootstrappers when rejected', (done) => {
+      const syncBootstrapper = {
+        bootstrap(context = {}) {
+          return Object.assign({}, context, {sync: true})
+        }
+      }
+      const errorAsync = {
+        bootstrap(context = {}) {
+          return new Promise((resolve, reject) => {
+            reject(new Error(':('))
+          })
+        }
+      }
+
+      const kernel = createKernel({
+        bootstrappers: [
+          errorAsync,
+          syncBootstrapper
+        ]
+      })
+
+      kernel.boot().catch(err => {
+        expect(err.message).toBe(':(')
+        done()
+      })
+    })
+
+    it('works with default contexts', () => {
+
+      const first = {
+        bootstrap(context = {firstDefault: true}) {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(Object.assign({}, context, {first: true}))
+            }, 10)
+          })
+        }
+      }
+
+      const second = {
+        bootstrap(context = {secondDefault: true}) {
+          return new Promise(resolve => {
+            setTimeout(() => {
+              resolve(Object.assign({}, context, {second: true}))
+            }, 10)
+          })
+        }
+      }
+
+      const kernel = createKernel({
+        bootstrappers: [first, second]
+      })
+
+      kernel.boot().then(res => {
+        expect(res).toEqual({
+          firstDefault: true, // initial bootsrapper called with undefined
+          first: true, // regular bootstrap call
+          second: true, // regular bootstrap call
+        })
+      })
+    })
+  })
+
+  describe('middleware support', () => {
+
   })
 })


### PR DESCRIPTION
This PR 
- introduces the concept of async bootstrappers via returning a promise,

``` js
const asyncBootstrapper = {
  bootstrap(context = {}) {
    return new Promise(resolve => {
      setTimeout(() => {
        resolve(Object.assign({}, context, {async: true}))
      }, 10)
    })
  }
}

const syncBootstrapper = {
  bootstrap(context = {}) {
    return Object.assign({}, context, {sync: true})
  }
}

const kernel = createKernel({
  bootstrappers: [
    syncBootstrapper,
    asyncBootstrapper
  ]
})

kernel.boot().then(res => {
  console.log(res) // => { async: true, sync: true }
})

```
- introduces the concept of `middlewares` (the idea is almost the exact copy of [middlewares in redux](http://redux.js.org/docs/advanced/Middleware.html):

``` js
const logger = bootstrapper => next => context => {
  console.info(`running bootstrapper(${bootstrapper.name})`)
  const newContext = next(context)
  console.info(`final context: ${JSON.stringify(newContext)}`)
  return newContext
}
```

Documentation will be available with new Pull Requests.
